### PR TITLE
Fix RH5 manual control simulation steps 

### DIFF
--- a/book/duckietown-robotics-development/05_simulating_modeling_controlling/01_simulation_duckietown.md
+++ b/book/duckietown-robotics-development/05_simulating_modeling_controlling/01_simulation_duckietown.md
@@ -77,13 +77,7 @@ What do you observe? Does this make sense? Why is it driving straight? Can you m
 
 ### Driving around in the simulator
 
-If you want to drive the robot around in simulation you might have read about the utility script `manual_control.py`. This is located in the root of the [gym_duckietown](https://github.com/duckietown/gym-duckietown) repository and can be run after making sure that all the dependencies are met. Clone the repository and in the root of it run the following:
-
-    laptop $ pip3 install -r requirements.txt
-    
-    laptop $ pip3 install -e .
-
-now run:
+If you want to drive the robot around in simulation you might have read about the utility script `manual_control.py`. This is located in the root of the [gym_duckietown](https://github.com/duckietown/gym-duckietown) repository and can be run after making sure that all the dependencies are met. Clone the repository and in the root of it run:
 
     laptop $ ./manual_control.py --env-name Duckietown-udem1-v0
 


### PR DESCRIPTION
Running these additional install commands actually install clashing packages which are not needed for running manual_control.py